### PR TITLE
Allow actor/director to connect to arbitrary coordinator host/port

### DIFF
--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -508,14 +508,26 @@ class ParameterControlModule(ParameterManager, ControlModule):
             name = f"viewer_{randint(0, 10000)}"
             name = self.settings.child("main_settings", "leco", "leco_name").setValue(name)
         return name
+    
+    def get_leco_host_port(self) -> tuple:
+        host = self.settings["main_settings", "leco", "host"]
+        port = self.settings["main_settings", "leco", "port"]
+        if host == '':
+            # take the localhost as default
+            host = 'localhost'
+        if port == '':
+            # take the default port as 12300
+            port = 12300
+        return (host, port)    
 
     def connect_leco(self, connect: bool) -> None:
         if connect:
             name = self.get_leco_name()
+            host, port = self.get_leco_host_port()
             try:
                 self._leco_client.name = name
             except AttributeError:
-                self._leco_client = self.listener_class(name=name)
+                self._leco_client = self.listener_class(name=name, host=host, port=port)
                 self._leco_client.cmd_signal.connect(self.process_tcpip_cmds)
             self._command_tcpip[ThreadCommand].connect(self._leco_client.queue_command)
             self._leco_client.start_listen()

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -61,7 +61,7 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
     def __init__(self, parent=None, params_state=None) -> None:
         DAQ_Move_base.__init__(self, parent=parent,
                                params_state=params_state)
-        LECODirector.__init__(self, host=self.settings['host'])
+        LECODirector.__init__(self, host=self.settings['host'], port=self.settings['port'])
 
         self.register_rpc_methods((
             self.set_units,  # to set units accordingly to the one of the actor

--- a/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
@@ -35,7 +35,7 @@ class DAQ_xDViewer_LECODirector(LECODirector, DAQ_Viewer_base):
     def __init__(self, parent=None, params_state=None, grabber_type: str = "0D", **kwargs) -> None:
         DAQ_Viewer_base.__init__(self, parent=parent,
                                  params_state=params_state)
-        LECODirector.__init__(self, host=self.settings['host'])
+        LECODirector.__init__(self, host=self.settings['host'], port=self.settings['port'])
         for method in (
             self.set_data,
         ):

--- a/src/pymodaq/utils/leco/leco_director.py
+++ b/src/pymodaq/utils/leco/leco_director.py
@@ -36,6 +36,7 @@ leco_parameters = [
     {'title': 'Actor name:', 'name': 'actor_name', 'type': 'str', 'value': "actor_name",
      'tip': 'Name of the actor plugin to communicate with.'},
     {'title': 'Coordinator Host:', 'name': 'host', 'type': 'str', 'value': config('network', "leco-server", "host")},
+    {'title': 'Coordinator Port:', 'name': 'port', 'type': 'int', 'value': config('network', "leco-server", "port")},
     {'title': 'Settings PyMoDAQ Client:', 'name': 'settings_client', 'type': 'group', 'children': []},
 ]
 


### PR DESCRIPTION
I was having issues connecting my actor to a coordinator running on another computer or with an arbitrary port number. I found that we never actually passed the host and port that a user inputs in the GUI to the PymodaqListener during initialization. I added a function that will take these values and pass them to the listener class when the connect leco method is called. 